### PR TITLE
Avoid too many modules are created

### DIFF
--- a/accel/tcg/tb-maint.c
+++ b/accel/tcg/tb-maint.c
@@ -886,10 +886,6 @@ static void tb_jmp_cache_inval_tb(TranslationBlock *tb)
 {
     CPUState *cpu;
 
-#if defined(EMSCRIPTEN) && !defined(CONFIG_TCG_INTERPRETER)
-    remove_tb(tb->tc.ptr);
-#endif
-    
     if (tb_cflags(tb) & CF_PCREL) {
         /* A TB may be at any virtual address */
         CPU_FOREACH(cpu) {

--- a/tcg/tcg.c
+++ b/tcg/tcg.c
@@ -6412,6 +6412,13 @@ int tcg_gen_code(TCGContext *s, TranslationBlock *tb, uint64_t pc_start)
     s->code_ptr += export_size;
     *size_base = export_size;
 
+    size_base = (uint32_t*)s->code_ptr;
+    s->code_ptr += 4;
+    int counter_size = get_core_nums() * 4;
+    memset(s->code_ptr, 0, counter_size);
+    s->code_ptr += counter_size;
+    *size_base = counter_size;
+    
     uint8_t *code_begin = s->code_ptr;
     s->code_ptr += 4; // placeholder for size
     *tci_code_off = s->code_ptr - s->code_buf;

--- a/tcg/wasm32.h
+++ b/tcg/wasm32.h
@@ -35,8 +35,6 @@ void set_unwinding_flag();
 
 int get_core_nums();
 
-void remove_tb(void *tb_ptr);
-
 void init_wasm32();
 
 #define INSTANTIATE_NUM 1500


### PR DESCRIPTION
This patch avoids OOM caused by too many modules are created.

- Limit maximum number of modules created simultaneously.
- Ensure removed modules are garbage collected by returinig the control to browser.